### PR TITLE
fix: image upload cancellation when image is removed

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,7 +36,7 @@ android {
         applicationId "com.hapramp"
         minSdkVersion 16
         targetSdkVersion 27
-        versionCode 28
+        versionCode 34
         versionName "0.0.14"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         multiDexEnabled true

--- a/app/src/main/java/com/hapramp/ui/activity/ProfileEditActivity.java
+++ b/app/src/main/java/com/hapramp/ui/activity/ProfileEditActivity.java
@@ -325,7 +325,7 @@ public class ProfileEditActivity extends AppCompatActivity implements ImageRotat
   }
 
   @Override
-  public void onImageRotationFixed(final String filePath, final boolean fileShouldBeDeleted, final int uid) {
+  public void onImageRotationFixed(final String filePath, final boolean fileShouldBeDeleted, final long uid) {
     mHandler.post(new Runnable() {
       @Override
       public void run() {
@@ -346,7 +346,7 @@ public class ProfileEditActivity extends AppCompatActivity implements ImageRotat
     }
   }
 
-  private void startUploading(final String filePath, final boolean fileShouldBeDeleted, final int uid) {
+  private void startUploading(final String filePath, final boolean fileShouldBeDeleted, final long uid) {
     File file = new File(filePath);
     final RequestBody requestFile = RequestBody.create(MediaType.parse("image/*"), file);
     MultipartBody.Part body = MultipartBody.Part.createFormData("upload", file.getName(), requestFile);

--- a/app/src/main/java/com/hapramp/utils/ImageRotationHandler.java
+++ b/app/src/main/java/com/hapramp/utils/ImageRotationHandler.java
@@ -18,7 +18,7 @@ public class ImageRotationHandler {
     this.mContext = context;
   }
 
-  public void checkOrientationAndFixImage(final String imagePath, final int uid) {
+  public void checkOrientationAndFixImage(final String imagePath, final long uid) {
     new Thread() {
       @Override
       public void run() {
@@ -69,7 +69,7 @@ public class ImageRotationHandler {
     return bitmap;
   }
 
-  private void saveRotatedBitampAndSendBackResults(Bitmap bitmap, String originalPath, int uid) {
+  private void saveRotatedBitampAndSendBackResults(Bitmap bitmap, String originalPath, long uid) {
     if (bitmap == null) {
       performCallback(originalPath, false, uid);
     } else {
@@ -97,7 +97,7 @@ public class ImageRotationHandler {
     }
   }
 
-  private void performCallback(String filePath, boolean needsToBeCleaned, int uid) {
+  private void performCallback(String filePath, boolean needsToBeCleaned, long uid) {
     if (imageRotationOperationListner != null) {
       imageRotationOperationListner.onImageRotationFixed(filePath, needsToBeCleaned, uid);
     }
@@ -108,6 +108,6 @@ public class ImageRotationHandler {
   }
 
   public interface ImageRotationOperationListner {
-    void onImageRotationFixed(String filePath, boolean fileShouldBeDeleted, int uid);
+    void onImageRotationFixed(String filePath, boolean fileShouldBeDeleted, long uid);
   }
 }


### PR DESCRIPTION
##### Issue:
If the user removes the image while post creation and chooses another image, the previous image is still uploading.

Now the upload request is canceled and the current image is prioritized over it.