### PR TITLE
Fix #196, add power down warning message

### DIFF
--- a/app/src/main/java/com/hapramp/ui/fragments/EarningFragment.java
+++ b/app/src/main/java/com/hapramp/ui/fragments/EarningFragment.java
@@ -424,11 +424,15 @@ public class EarningFragment extends Fragment implements
     finalVestsReward = _rewardVests;
     try {
       if (sbdReward > 0) {
-        rewardPanelText.append(finalSBDReward);
+        rewardPanelText
+          .append(finalSBDReward)
+          .append(" ");
         rewardExists = true;
       }
       if (steemReward > 0) {
-        rewardPanelText.append(finalSteemReward);
+        rewardPanelText
+          .append(finalSteemReward)
+          .append(" ");
         rewardExists = true;
       }
       if (vestsReward > 0) {

--- a/app/src/main/res/layout/activity_power_down.xml
+++ b/app/src/main/res/layout/activity_power_down.xml
@@ -112,6 +112,17 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" />
 
+        <TextView
+            android:layout_below="@+id/continueBtn"
+            android:paddingLeft="16dp"
+            android:paddingRight="16dp"
+            android:textSize="12sp"
+            android:layout_marginTop="16dp"
+            android:textColor="@color/Black38"
+            android:text="@string/power_down_warning"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
     </RelativeLayout>
 
 </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,4 +29,5 @@
     <string name="community_save_progress_mesaage">Saving your communities...</string>
     <string name="app_exit_alert_message">Exit?</string>
     <string name="comment_fetch_error_text">Error occurred while fetching comments.</string>
+    <string name="power_down_warning">Leaving less than 5 STEEM POWER in your account is not recommended and can leave your account in a unusable state.</string>
 </resources>


### PR DESCRIPTION
This PR includes:
 - Add space between items in Claim Reward Button
 - Add warning message:

<img src="https://user-images.githubusercontent.com/10809719/45893466-ec573280-bde8-11e8-9221-0c627c8b876e.png" width="320px" height="640px"/>
