### PR TITLE
fix notification click redirect for reply,mention,comment

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,7 +37,7 @@ android {
         applicationId "com.hapramp"
         minSdkVersion 16
         targetSdkVersion 27
-        versionCode 56
+        versionCode 57
         versionName "0.0.16"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         multiDexEnabled true

--- a/app/src/main/java/com/hapramp/notification/NotificationHandler.java
+++ b/app/src/main/java/com/hapramp/notification/NotificationHandler.java
@@ -73,6 +73,7 @@ public class NotificationHandler {
                 showCommentDirectedNotification(
                   baseNotificationModel.getNotificationId(),
                   ((ReplyNotificationModel) baseNotificationModel).author,
+                  ((ReplyNotificationModel) baseNotificationModel).parent_permlink,
                   ((ReplyNotificationModel) baseNotificationModel).permlink);
 
                 break;
@@ -98,6 +99,7 @@ public class NotificationHandler {
                 showMentionDirectedNotification(
                   baseNotificationModel.getNotificationId(),
                   ((MentionNotificationModel) baseNotificationModel).author,
+                  ((MentionNotificationModel) baseNotificationModel).parent_permlink,
                   ((MentionNotificationModel) baseNotificationModel).permlink
                 );
                 break;
@@ -142,7 +144,7 @@ public class NotificationHandler {
     String author = HaprampPreferenceManager.getInstance().getCurrentSteemUsername();
     String title = "Reblog";
     String content = reblogger + " shared your post";
-    PendingIntent pendingIntent = getPostNotificationPendingIntent(context, notificationId, author, permlink);
+    PendingIntent pendingIntent = getPostNotificationPendingIntent(context, notificationId, author,"", permlink);
     addNotificationToTray(HapRampMain.getContext(), pendingIntent, title, content);
   }
 
@@ -151,13 +153,13 @@ public class NotificationHandler {
    * @param commentor      user who created comment
    * @param permlink       permlink of new comment/reply.
    */
-  private static void showCommentDirectedNotification(String notificationId, String commentor, String permlink) {
+  private static void showCommentDirectedNotification(String notificationId, String commentor, String parentPermlink, String permlink) {
     Context context = HapRampMain.getContext();
     //you are the author of the post
     String author = HaprampPreferenceManager.getInstance().getCurrentSteemUsername();
     String title = "Comment";
     String content = commentor + " commented on your post";
-    PendingIntent pendingIntent = getPostNotificationPendingIntent(context, notificationId, author, permlink);
+    PendingIntent pendingIntent = getPostNotificationPendingIntent(context, notificationId, author, parentPermlink, permlink);
     addNotificationToTray(HapRampMain.getContext(), pendingIntent, title, content);
   }
 
@@ -172,7 +174,7 @@ public class NotificationHandler {
     String author = HaprampPreferenceManager.getInstance().getCurrentSteemUsername();
     String title = "Vote";
     String content = voter + " voted your post";
-    PendingIntent pendingIntent = getPostNotificationPendingIntent(context, notificationId, author, permlink);
+    PendingIntent pendingIntent = getPostNotificationPendingIntent(context, notificationId, author, "", permlink);
     addNotificationToTray(HapRampMain.getContext(), pendingIntent, title, content);
   }
 
@@ -195,13 +197,13 @@ public class NotificationHandler {
    * @param mentioner      user who mentioned you in his/her post.
    * @param permlink       permlink of post in which you were mentioned.
    */
-  private static void showMentionDirectedNotification(String notificationId, String mentioner, String permlink) {
+  private static void showMentionDirectedNotification(String notificationId, String mentioner, String parentPermlink, String permlink) {
     Context context = HapRampMain.getContext();
     //you are the author of the post
     String author = HaprampPreferenceManager.getInstance().getCurrentSteemUsername();
     String title = "Mention";
     String content = mentioner + " mentioned you in a post";
-    PendingIntent pendingIntent = getPostNotificationPendingIntent(context, notificationId, author, permlink);
+    PendingIntent pendingIntent = getPostNotificationPendingIntent(context, notificationId, author, parentPermlink, permlink);
     addNotificationToTray(HapRampMain.getContext(), pendingIntent, title, content);
   }
 
@@ -235,11 +237,13 @@ public class NotificationHandler {
   private static PendingIntent getPostNotificationPendingIntent(Context context,
                                                                 String notificationId,
                                                                 String author,
+                                                                String parentPermlink,
                                                                 String permlink) {
     Intent intent = new Intent(context, DetailedActivity.class);
     Bundle bundle = new Bundle();
     bundle.putString(Constants.EXTRAA_KEY_NOTIFICATION_ID, notificationId);
     bundle.putString(Constants.EXTRAA_KEY_POST_AUTHOR, author);
+    bundle.putString(Constants.EXTRAA_KEY_PARENT_PERMLINK, parentPermlink);
     bundle.putString(Constants.EXTRAA_KEY_POST_PERMLINK, permlink);
     intent.putExtras(bundle);
     TaskStackBuilder stackBuilder = TaskStackBuilder.create(context);

--- a/app/src/main/java/com/hapramp/notification/NotificationKey.java
+++ b/app/src/main/java/com/hapramp/notification/NotificationKey.java
@@ -6,7 +6,7 @@ public class NotificationKey {
   public static final String KEY_AUTHOR = "author";
   public static final String KEY_PERMLINK = "permlink";
   public static final String KEY_TIMESTAMP = "timestamp";
-  public static final String KEY_IS_ROOT_POST = "is_root_post";
+  public static final String KEY_IS_ROOT_POST = "rootPost";
   public static final String KEY_FOLLOWER = "follower";
   public static final String KEY_ACCOUNT = "account";
   public static final String KEY_VOTER = "voter";

--- a/app/src/main/java/com/hapramp/notification/NotificationParser.java
+++ b/app/src/main/java/com/hapramp/notification/NotificationParser.java
@@ -34,11 +34,10 @@ public class NotificationParser {
               String.valueOf(map.get(NotificationKey.KEY_PERMLINK)),
               String.valueOf(map.get(NotificationKey.KEY_WEIGHT)),
               String.valueOf(map.get(NotificationKey.KEY_TIMESTAMP)),
-              String.valueOf(map.get(NotificationKey.KEY_PARENT_PERMLINK))
+              String.valueOf(map.get(NotificationKey.KEY_PARENT_PERMLINK) != null ? map.get(NotificationKey.KEY_PARENT_PERMLINK) : "")
             );
 
           } else if (type.equals(NotificationKey.NOTIFICATION_TYPE_MENTION)) {
-
             baseNotificationType = new MentionNotificationModel(
               String.valueOf(map.get(NotificationKey.KEY_TYPE)),
               Boolean.valueOf(map.get(NotificationKey.KEY_IS_ROOT_POST)),
@@ -46,7 +45,6 @@ public class NotificationParser {
               String.valueOf(map.get(NotificationKey.KEY_PARENT_PERMLINK)),
               String.valueOf(map.get(NotificationKey.KEY_PERMLINK)),
               String.valueOf(map.get(NotificationKey.KEY_TIMESTAMP)));
-
           } else if (type.equals(NotificationKey.NOTIFICATION_TYPE_REBLOG)) {
 
             baseNotificationType = new ReblogNotificationModel(
@@ -54,13 +52,13 @@ public class NotificationParser {
               String.valueOf(map.get(NotificationKey.KEY_ACCOUNT)),
               String.valueOf(map.get(NotificationKey.KEY_PERMLINK)),
               String.valueOf(map.get(NotificationKey.KEY_TIMESTAMP)),
-              String.valueOf(map.get(NotificationKey.KEY_PARENT_PERMLINK)));
+              String.valueOf(map.get(NotificationKey.KEY_PARENT_PERMLINK) != null ? map.get(NotificationKey.KEY_PARENT_PERMLINK) : ""));
 
           } else if (type.equals(NotificationKey.NOTIFICATION_TYPE_REPLY)) {
 
             baseNotificationType = new ReplyNotificationModel(
               String.valueOf(map.get(NotificationKey.KEY_TYPE)),
-              String.valueOf(map.get(NotificationKey.KEY_PARENT_PERMLINK)),
+              String.valueOf(map.get(NotificationKey.KEY_PARENT_PERMLINK) != null ? map.get(NotificationKey.KEY_PARENT_PERMLINK) : ""),
               String.valueOf(map.get(NotificationKey.KEY_AUTHOR)),
               String.valueOf(map.get(NotificationKey.KEY_PERMLINK)),
               String.valueOf(map.get(NotificationKey.KEY_TIMESTAMP)));
@@ -72,13 +70,12 @@ public class NotificationParser {
               String.valueOf(map.get(NotificationKey.KEY_AMOUNT)),
               String.valueOf(map.get(NotificationKey.KEY_MEMO)),
               String.valueOf(map.get(NotificationKey.KEY_TIMESTAMP)));
-
           }
         }
       }
     }
     catch (Exception e) {
-
+      e.printStackTrace();
     }
     return baseNotificationType;
   }

--- a/app/src/main/java/com/hapramp/notification/model/MentionNotificationModel.java
+++ b/app/src/main/java/com/hapramp/notification/model/MentionNotificationModel.java
@@ -1,66 +1,59 @@
 package com.hapramp.notification.model;
 
-import com.google.gson.Gson;
 
 public class MentionNotificationModel extends BaseNotificationModel {
   public String type;
-  public boolean isRootPost;
+  public boolean is_root_post;
   public String author;
-  public String parentPermlink;
+  public String parent_permlink;
   public String permlink;
   public String timestamp;
 
-  public MentionNotificationModel(String type, boolean isRootPost, String author, String parentPermlink, String permlink, String timestamp) {
+  public MentionNotificationModel(String type, boolean isRootPost, String author, String parent_permlink, String permlink, String timestamp) {
     this.type = type;
-    this.isRootPost = isRootPost;
+    this.is_root_post = isRootPost;
     this.author = author;
-    this.parentPermlink = parentPermlink;
+    this.parent_permlink = parent_permlink;
     this.permlink = permlink;
     this.timestamp = timestamp;
   }
 
-  public String getParentPermlink() {
-    return parentPermlink;
-  }
-
-  public void setParentPermlink(String parentPermlink) {
-    this.parentPermlink = parentPermlink;
-  }
-
-  public MentionNotificationModel(String type, String notificationId, String type1, boolean isRootPost, String author, String parentPermlink, String permlink, String timestamp) {
+  public MentionNotificationModel(String type, String notificationId, String type1, boolean isRootPost, String author, String parent_permlink, String permlink, String timestamp) {
     super(type, notificationId);
     this.type = type1;
-    this.isRootPost = isRootPost;
+    this.is_root_post = isRootPost;
     this.author = author;
-    this.parentPermlink = parentPermlink;
+    this.parent_permlink = parent_permlink;
     this.permlink = permlink;
     this.timestamp = timestamp;
   }
 
-  public MentionNotificationModel(String type, String type1, boolean isRootPost, String author, String parentPermlink, String permlink, String timestamp) {
+  public MentionNotificationModel(String type, String type1, boolean isRootPost, String author, String parent_permlink, String permlink, String timestamp) {
     super(type);
     this.type = type1;
-    this.isRootPost = isRootPost;
+    this.is_root_post = isRootPost;
     this.author = author;
-    this.parentPermlink = parentPermlink;
+    this.parent_permlink = parent_permlink;
     this.permlink = permlink;
     this.timestamp = timestamp;
   }
 
+  @Override
   public String getType() {
     return type;
   }
 
+  @Override
   public void setType(String type) {
     this.type = type;
   }
 
-  public boolean isRootPost() {
-    return isRootPost;
+  public boolean isIs_root_post() {
+    return is_root_post;
   }
 
-  public void setRootPost(boolean rootPost) {
-    isRootPost = rootPost;
+  public void setIs_root_post(boolean is_root_post) {
+    this.is_root_post = is_root_post;
   }
 
   public String getAuthor() {
@@ -69,6 +62,14 @@ public class MentionNotificationModel extends BaseNotificationModel {
 
   public void setAuthor(String author) {
     this.author = author;
+  }
+
+  public String getParent_permlink() {
+    return parent_permlink;
+  }
+
+  public void setParent_permlink(String parent_permlink) {
+    this.parent_permlink = parent_permlink;
   }
 
   public String getPermlink() {
@@ -86,5 +87,4 @@ public class MentionNotificationModel extends BaseNotificationModel {
   public void setTimestamp(String timestamp) {
     this.timestamp = timestamp;
   }
-
 }

--- a/app/src/main/java/com/hapramp/notification/model/ReblogNotificationModel.java
+++ b/app/src/main/java/com/hapramp/notification/model/ReblogNotificationModel.java
@@ -5,40 +5,40 @@ public class ReblogNotificationModel  extends BaseNotificationModel {
   public String account;
   public String permlink;
   public String timestamp;
-  public String parentPermlink;
+  public String parent_permlink;
 
-  public ReblogNotificationModel(String type, String account, String permlink, String timestamp, String parentPermlink) {
+  public ReblogNotificationModel(String type, String account, String permlink, String timestamp, String parent_permlink) {
     this.type = type;
     this.account = account;
     this.permlink = permlink;
     this.timestamp = timestamp;
-    this.parentPermlink = parentPermlink;
+    this.parent_permlink = parent_permlink;
   }
 
   public String getParentPermlink() {
-    return parentPermlink;
+    return parent_permlink;
   }
 
-  public void setParentPermlink(String parentPermlink) {
-    this.parentPermlink = parentPermlink;
+  public void setParentPermlink(String parent_permlink) {
+    this.parent_permlink = parent_permlink;
   }
 
-  public ReblogNotificationModel(String type, String notificationId, String type1, String account, String permlink, String timestamp, String parentPermlink) {
+  public ReblogNotificationModel(String type, String notificationId, String type1, String account, String permlink, String timestamp, String parent_permlink) {
     super(type, notificationId);
     this.type = type1;
     this.account = account;
     this.permlink = permlink;
     this.timestamp = timestamp;
-    this.parentPermlink = parentPermlink;
+    this.parent_permlink = parent_permlink;
   }
 
-  public ReblogNotificationModel(String type, String type1, String account, String permlink, String timestamp, String parentPermlink) {
+  public ReblogNotificationModel(String type, String type1, String account, String permlink, String timestamp, String parent_permlink) {
     super(type);
     this.type = type1;
     this.account = account;
     this.permlink = permlink;
     this.timestamp = timestamp;
-    this.parentPermlink = parentPermlink;
+    this.parent_permlink = parent_permlink;
   }
 
   public String getType() {
@@ -80,7 +80,7 @@ public class ReblogNotificationModel  extends BaseNotificationModel {
       ", account='" + account + '\'' +
       ", permlink='" + permlink + '\'' +
       ", timestamp='" + timestamp + '\'' +
-      ", parentPermlink='" + parentPermlink + '\'' +
+      ", parent_permlink='" + parent_permlink + '\'' +
       '}';
   }
 }

--- a/app/src/main/java/com/hapramp/notification/model/ReplyNotificationModel.java
+++ b/app/src/main/java/com/hapramp/notification/model/ReplyNotificationModel.java
@@ -1,6 +1,5 @@
 package com.hapramp.notification.model;
 
-import com.google.gson.Gson;
 
 public class ReplyNotificationModel  extends BaseNotificationModel {
   public String type;

--- a/app/src/main/java/com/hapramp/notification/model/VoteNotificationModel.java
+++ b/app/src/main/java/com/hapramp/notification/model/VoteNotificationModel.java
@@ -7,7 +7,7 @@ public class VoteNotificationModel extends BaseNotificationModel {
   public String permlink;
   public String weight;
   public String timestamp;
-  public String parentPermlink;
+  public String parent_permlink;
 
   public VoteNotificationModel(String type, String voter, String permlink, String weight, String timestamp, String parentPermlink) {
     this.type = type;
@@ -15,41 +15,15 @@ public class VoteNotificationModel extends BaseNotificationModel {
     this.permlink = permlink;
     this.weight = weight;
     this.timestamp = timestamp;
-    this.parentPermlink = parentPermlink;
+    this.parent_permlink = parentPermlink;
   }
 
-  public String getParentPermlink() {
-    return parentPermlink;
-  }
-
-  public void setParentPermlink(String parentPermlink) {
-    this.parentPermlink = parentPermlink;
-  }
-
-  public VoteNotificationModel(String type, String notificationId, String type1, String voter, String permlink, String weight, String timestamp, String parentPermlink) {
-    super(type, notificationId);
-    this.type = type1;
-    this.voter = voter;
-    this.permlink = permlink;
-    this.weight = weight;
-    this.timestamp = timestamp;
-    this.parentPermlink = parentPermlink;
-  }
-
-  public VoteNotificationModel(String type, String type1, String voter, String permlink, String weight, String timestamp, String parentPermlink) {
-    super(type);
-    this.type = type1;
-    this.voter = voter;
-    this.permlink = permlink;
-    this.weight = weight;
-    this.timestamp = timestamp;
-    this.parentPermlink = parentPermlink;
-  }
-
+  @Override
   public String getType() {
     return type;
   }
 
+  @Override
   public void setType(String type) {
     this.type = type;
   }
@@ -84,6 +58,14 @@ public class VoteNotificationModel extends BaseNotificationModel {
 
   public void setTimestamp(String timestamp) {
     this.timestamp = timestamp;
+  }
+
+  public String getParent_permlink() {
+    return parent_permlink;
+  }
+
+  public void setParent_permlink(String parent_permlink) {
+    this.parent_permlink = parent_permlink;
   }
 
   @Override

--- a/app/src/main/java/com/hapramp/ui/activity/DetailedActivity.java
+++ b/app/src/main/java/com/hapramp/ui/activity/DetailedActivity.java
@@ -146,6 +146,8 @@ public class DetailedActivity extends AppCompatActivity implements
   TextView ratingDesc;
   @BindView(R.id.voters_peek_view)
   VoterPeekView votersPeekView;
+  @BindView(R.id.gotoParentBtn)
+  TextView gotoParentBtn;
   private Handler mHandler;
   private Feed post;
   private ProgressDialog progressDialog;
@@ -201,13 +203,39 @@ public class DetailedActivity extends AppCompatActivity implements
     if (bundle.getString(Constants.EXTRAA_KEY_POST_AUTHOR) != null) {
       String author = bundle.getString(Constants.EXTRAA_KEY_POST_AUTHOR);
       String permlink = bundle.getString(Constants.EXTRAA_KEY_POST_PERMLINK);
+      final String parentPermlink = bundle.getString(Constants.EXTRAA_KEY_PARENT_PERMLINK, "");
       String notifId = getIntent().getExtras().getString(Constants.EXTRAA_KEY_NOTIFICATION_ID, null);
+      Log.d("DetailedPost",parentPermlink+" ---");
+      if (parentPermlink.length() > 0) {
+        //show goto parent button
+        if (gotoParentBtn != null) {
+          gotoParentBtn.setVisibility(View.VISIBLE);
+          gotoParentBtn.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+              String me = HaprampPreferenceManager.getInstance().getCurrentSteemUsername();
+              if (me.length() > 0) {
+                openDetailsPage(me,parentPermlink);
+              }
+            }
+          });
+        }
+      }
       if (notifId != null) {
         FirebaseNotificationStore.markAsRead(notifId);
       }
       showFeedLoading(true);
       requestSingleFeed(author, permlink);
     }
+  }
+
+  private void openDetailsPage(String author, String permlink) {
+    Intent intent = new Intent(this, DetailedActivity.class);
+    Bundle bundle = new Bundle();
+    bundle.putString(Constants.EXTRAA_KEY_POST_AUTHOR, author);
+    bundle.putString(Constants.EXTRAA_KEY_POST_PERMLINK, permlink);
+    intent.putExtras(bundle);
+    startActivity(intent);
   }
 
   private void bindPostValues(Feed feed) {
@@ -360,10 +388,6 @@ public class DetailedActivity extends AppCompatActivity implements
     requestReplies();
   }
 
-  private void requestReplies() {
-    dataStore.requestComments(this.post.getAuthor(), this.post.getPermlink(), this);
-  }
-
   @Override
   public void onCommentCreateFailed() {
     hideProgress();
@@ -373,6 +397,10 @@ public class DetailedActivity extends AppCompatActivity implements
     if (progressDialog != null) {
       progressDialog.dismiss();
     }
+  }
+
+  private void requestReplies() {
+    dataStore.requestComments(this.post.getAuthor(), this.post.getPermlink(), this);
   }
 
   private void setCommentCount(int count) {

--- a/app/src/main/java/com/hapramp/ui/adapters/NotificationAdapter.java
+++ b/app/src/main/java/com/hapramp/ui/adapters/NotificationAdapter.java
@@ -5,7 +5,6 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -138,11 +137,13 @@ public class NotificationAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
   private void navigateToDetailsPage(Context context,
                                      String notificationId,
                                      String author,
+                                     String parentPermlink,
                                      String permlink) {
     Intent intent = new Intent(context, DetailedActivity.class);
     Bundle bundle = new Bundle();
     bundle.putString(Constants.EXTRAA_KEY_NOTIFICATION_ID, notificationId);
     bundle.putString(Constants.EXTRAA_KEY_POST_AUTHOR, author);
+    bundle.putString(Constants.EXTRAA_KEY_PARENT_PERMLINK, parentPermlink);
     bundle.putString(Constants.EXTRAA_KEY_POST_PERMLINK, permlink);
     intent.putExtras(bundle);
     context.startActivity(intent);
@@ -208,11 +209,10 @@ public class NotificationAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
       itemView.setOnClickListener(new View.OnClickListener() {
         @Override
         public void onClick(View view) {
-          //you are the author of the post
-          final String author = HaprampPreferenceManager.getInstance().getCurrentSteemUsername();
           navigateToDetailsPage(itemView.getContext(),
             mentionNotificationModel.getNotificationId(),
-            author,
+            mentionNotificationModel.getAuthor(),
+            mentionNotificationModel.getParent_permlink(),
             mentionNotificationModel.getPermlink());
         }
       });
@@ -246,6 +246,7 @@ public class NotificationAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
           navigateToDetailsPage(itemView.getContext(),
             reblogNotificationModel.getNotificationId(),
             author,
+            reblogNotificationModel.getParentPermlink(),
             reblogNotificationModel.getPermlink());
         }
       });
@@ -274,11 +275,10 @@ public class NotificationAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
       itemView.setOnClickListener(new View.OnClickListener() {
         @Override
         public void onClick(View view) {
-          //you are the author of the post
-          final String author = HaprampPreferenceManager.getInstance().getCurrentSteemUsername();
           navigateToDetailsPage(itemView.getContext(),
             replyNotificationModel.getNotificationId(),
-            author,
+            replyNotificationModel.getAuthor(),
+            replyNotificationModel.getParent_permlink(),
             replyNotificationModel.getPermlink());
         }
       });
@@ -342,6 +342,7 @@ public class NotificationAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
           navigateToDetailsPage(itemView.getContext(),
             voteNotificationModel.getNotificationId(),
             author,
+            voteNotificationModel.getParent_permlink(),
             voteNotificationModel.getPermlink());
         }
       });

--- a/app/src/main/res/drawable/goto_parent_post_btn_bg.xml
+++ b/app/src/main/res/drawable/goto_parent_post_btn_bg.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <size
+        android:width="10dp"
+        android:height="10dp" />
+    <solid android:color="#6eeeeeee" />
+    <corners android:radius="2dp" />
+    <stroke
+        android:width="1dp"
+        android:color="#eeeeee" />
+</shape>

--- a/app/src/main/res/layout/activity_details_post.xml
+++ b/app/src/main/res/layout/activity_details_post.xml
@@ -96,6 +96,24 @@
             </RelativeLayout>
 
             <TextView
+                android:visibility="gone"
+                android:paddingTop="8dp"
+                android:paddingBottom="8dp"
+                android:paddingLeft="8dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginBottom="8dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginRight="16dp"
+                android:clickable="true"
+                android:focusable="true"
+                android:background="@drawable/goto_parent_post_btn_bg"
+                android:id="@+id/gotoParentBtn"
+                android:text="Go to parent post"
+                android:textSize="16sp"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <TextView
                 android:id="@+id/post_title"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"


### PR DESCRIPTION
Applying this PR:
 - Clicking on `Reply` notification opens details page containing the reply
 - Clicking on `Mention` notification opens details page containing the mention.
 - Clicking on `Comment` notification opens details page containing the comment.
 - Details page contains a button to navigate to parent post.