### PR TITLE
fix draft saving in contest editor

### DIFF
--- a/app/src/main/java/com/hapramp/draft/DraftListItemModel.java
+++ b/app/src/main/java/com/hapramp/draft/DraftListItemModel.java
@@ -2,7 +2,7 @@ package com.hapramp.draft;
 
 public class DraftListItemModel {
   private String title;
-  private long draftId;
+  private int draftId;
   private String draftType;
   private String json;
   private String lastModified;
@@ -35,7 +35,7 @@ public class DraftListItemModel {
     return draftId;
   }
 
-  public void setDraftId(long draftId) {
+  public void setDraftId(int draftId) {
     this.draftId = draftId;
   }
 

--- a/app/src/main/java/com/hapramp/draft/DraftsHelper.java
+++ b/app/src/main/java/com/hapramp/draft/DraftsHelper.java
@@ -37,14 +37,14 @@ public class DraftsHelper {
       @Override
       public void onResponse(Call<DraftUploadResponse> call, Response<DraftUploadResponse> response) {
         if (draftsHelperCallback != null) {
-          draftsHelperCallback.onNewDraftSaved(response.isSuccessful());
+          draftsHelperCallback.onNewDraftSaved(response.isSuccessful(), response.body().getmId());
         }
       }
 
       @Override
       public void onFailure(Call<DraftUploadResponse> call, Throwable t) {
         if (draftsHelperCallback != null) {
-          draftsHelperCallback.onNewDraftSaved(false);
+          draftsHelperCallback.onNewDraftSaved(false, 0);
         }
       }
     });
@@ -91,13 +91,13 @@ public class DraftsHelper {
       @Override
       public void onResponse(Call<DraftUploadResponse> call, Response<DraftUploadResponse> response) {
         if (draftsHelperCallback != null) {
-          draftsHelperCallback.onDraftUpdated(response.isSuccessful());
+          draftsHelperCallback.onDraftUpdated(response.isSuccessful(), response.body().getmId());
         }
       }
 
       @Override
       public void onFailure(Call<DraftUploadResponse> call, Throwable t) {
-        draftsHelperCallback.onDraftUpdated(false);
+        draftsHelperCallback.onDraftUpdated(false, 0);
       }
     });
   }
@@ -144,9 +144,9 @@ public class DraftsHelper {
   }
 
   public interface DraftsHelperCallback {
-    void onNewDraftSaved(boolean success);
+    void onNewDraftSaved(boolean success, int draftId);
 
-    void onDraftUpdated(boolean success);
+    void onDraftUpdated(boolean success, int draftId);
 
     void onDraftDeleted(boolean success);
   }

--- a/app/src/main/java/com/hapramp/ui/activity/CompetitionCreatorActivity.java
+++ b/app/src/main/java/com/hapramp/ui/activity/CompetitionCreatorActivity.java
@@ -161,7 +161,7 @@ public class CompetitionCreatorActivity extends AppCompatActivity implements Jud
   private ProgressDialog progressDialog;
   private SteemPostCreator steemPostCreator;
   private boolean isCompetitionPosted;
-  private long mDraftId;
+  private long mDraftId = NO_COMP_DRAFT;
   private DraftsHelper mDraftHelper;
   private CompetitionCreateBody competitionCreateBody;
   private boolean shouldSaveOrUpdateDraft = true;
@@ -331,6 +331,7 @@ public class CompetitionCreatorActivity extends AppCompatActivity implements Jud
       showPublishingProgressDialog(true, "Saving changes...");
       shouldSaveOrUpdateDraft = false;
       updateDraft();
+      closeAfterSomeTime();
       return;
     }
 
@@ -537,6 +538,16 @@ public class CompetitionCreatorActivity extends AppCompatActivity implements Jud
     mDraftHelper.updateContestDraft(competitionDraftModel);
   }
 
+  private void closeAfterSomeTime() {
+    new Handler().postDelayed(new Runnable() {
+      @Override
+      public void run() {
+        showPublishingProgressDialog(false, "");
+        close();
+      }
+    }, 2000);
+  }
+
   private void close() {
     finish();
     overridePendingTransition(R.anim.slide_down_enter, R.anim.slide_down_exit);
@@ -740,9 +751,8 @@ public class CompetitionCreatorActivity extends AppCompatActivity implements Jud
    * Adds new draft to database.
    */
   private void addNewDraft() {
-    mDraftId = System.currentTimeMillis();
     ContestDraftModel competitionDraftModel = new ContestDraftModel();
-    competitionDraftModel.setDraftId(mDraftId);
+    competitionDraftModel.setDraftId(0);
     competitionDraftModel.setCompetitionTitle(competitionTitle.getText().toString());
     competitionDraftModel.setCompetitionDescription(competitionDescription.getText().toString());
     competitionDraftModel.setCompetitionRules(competitionRules.getText().toString());
@@ -833,6 +843,11 @@ public class CompetitionCreatorActivity extends AppCompatActivity implements Jud
       });
   }
 
+  private String getFullpermlink() {
+    final String username = HaprampPreferenceManager.getInstance().getCurrentSteemUsername();
+    return String.format("%s/%s", username, contestAnnouncementSteemPostPermlink);
+  }
+
   @Override
   public void onPostCreationFailedOnSteem(String msg) {
     showPublishingProgressDialog(false, "");
@@ -840,7 +855,8 @@ public class CompetitionCreatorActivity extends AppCompatActivity implements Jud
   }
 
   @Override
-  public void onNewDraftSaved(boolean success) {
+  public void onNewDraftSaved(boolean success, int draftId) {
+    mDraftId = draftId;
     if (success) {
       toast("Draft Saved");
     } else {
@@ -849,19 +865,13 @@ public class CompetitionCreatorActivity extends AppCompatActivity implements Jud
   }
 
   @Override
-  public void onDraftUpdated(boolean success) {
+  public void onDraftUpdated(boolean success, int draftId) {
     showPublishingProgressDialog(false, "");
-    close();
   }
 
   @Override
   public void onDraftDeleted(boolean success) {
 
-  }
-
-  private String getFullpermlink(){
-    final String username = HaprampPreferenceManager.getInstance().getCurrentSteemUsername();
-    return String.format("%s/%s", username, contestAnnouncementSteemPostPermlink);
   }
 }
 

--- a/app/src/main/java/com/hapramp/ui/activity/CreateArticleActivity.java
+++ b/app/src/main/java/com/hapramp/ui/activity/CreateArticleActivity.java
@@ -96,7 +96,7 @@ public class CreateArticleActivity extends AppCompatActivity implements SteemPos
   private String body;
   private List<String> images;
   private DraftsHelper draftsHelper;
-  private long mDraftId;
+  private long mDraftId = NO_DRAFT;
   private boolean blogPublished;
   private boolean leftActivityWithPurpose = false;
 
@@ -501,7 +501,8 @@ public class CreateArticleActivity extends AppCompatActivity implements SteemPos
   }
 
   @Override
-  public void onNewDraftSaved(boolean success) {
+  public void onNewDraftSaved(boolean success,int draftId) {
+    mDraftId = draftId;
     if (success) {
       Toast.makeText(CreateArticleActivity.this, "Draft saved", Toast.LENGTH_LONG).show();
     } else {
@@ -510,7 +511,8 @@ public class CreateArticleActivity extends AppCompatActivity implements SteemPos
   }
 
   @Override
-  public void onDraftUpdated(boolean success) {
+  public void onDraftUpdated(boolean success,int draftId) {
+    mDraftId = draftId;
     showProgressDialog(false, "");
     closeEditor();
   }

--- a/app/src/main/java/com/hapramp/ui/activity/CreatePostActivity.java
+++ b/app/src/main/java/com/hapramp/ui/activity/CreatePostActivity.java
@@ -569,11 +569,13 @@ public class CreatePostActivity extends AppCompatActivity implements SteemPostCr
   }
 
   @Override
-  public void onNewDraftSaved(boolean success) {
+  public void onNewDraftSaved(boolean success,int mDraftId) {
+    this.mDraftId = mDraftId;
   }
 
   @Override
-  public void onDraftUpdated(boolean success) {
+  public void onDraftUpdated(boolean success,int draftId) {
+    this.mDraftId = draftId;
     showPublishingProgressDialog(false, "");
     close();
   }

--- a/app/src/main/java/com/hapramp/ui/adapters/ProfileFragmentPagerAdapter.java
+++ b/app/src/main/java/com/hapramp/ui/adapters/ProfileFragmentPagerAdapter.java
@@ -5,6 +5,7 @@ import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentPagerAdapter;
+import android.util.Log;
 
 import com.hapramp.preferences.HaprampPreferenceManager;
 import com.hapramp.ui.fragments.EarningFragment;
@@ -45,7 +46,10 @@ public class ProfileFragmentPagerAdapter extends FragmentPagerAdapter {
     titles.add("Credits");
     titles.add("Wallet");
     addDraftsTab(username);
-    addMyCompetitionsAfterEligibilityCheck(username);
+    Log.d("DraftingTest",username);
+    MyCompetitionsFragment myCompetitionsFragment = new MyCompetitionsFragment();
+    fragments.add(myCompetitionsFragment);
+    titles.add("My Competitions");
   }
 
   private void addDraftsTab(String username) {
@@ -59,18 +63,6 @@ public class ProfileFragmentPagerAdapter extends FragmentPagerAdapter {
     }
     catch (Exception e) {
       e.printStackTrace();
-    }
-  }
-
-  private void addMyCompetitionsAfterEligibilityCheck(String username) {
-    //username is same as logged-in user
-    //and eligible for competitions creation
-    if (username.equals(HaprampPreferenceManager.getInstance().getCurrentSteemUsername())) {
-      if (HaprampPreferenceManager.getInstance().isEligibleForCompetitionCreation()) {
-        MyCompetitionsFragment myCompetitionsFragment = new MyCompetitionsFragment();
-        fragments.add(myCompetitionsFragment);
-        titles.add("My Competitions");
-      }
     }
   }
 

--- a/app/src/main/java/com/hapramp/ui/fragments/MyDraftsFragment.java
+++ b/app/src/main/java/com/hapramp/ui/fragments/MyDraftsFragment.java
@@ -187,12 +187,12 @@ public class MyDraftsFragment extends Fragment implements DraftsHelper.DraftsHel
   }
 
   @Override
-  public void onNewDraftSaved(boolean success) {
+  public void onNewDraftSaved(boolean success,int draftId) {
 
   }
 
   @Override
-  public void onDraftUpdated(boolean success) {
+  public void onDraftUpdated(boolean success,int draftId) {
 
   }
 

--- a/app/src/main/java/com/hapramp/ui/fragments/ProfileFragment.java
+++ b/app/src/main/java/com/hapramp/ui/fragments/ProfileFragment.java
@@ -2,10 +2,11 @@ package com.hapramp.ui.fragments;
 
 import android.content.Context;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.design.widget.TabLayout;
 import android.support.v4.app.Fragment;
 import android.support.v4.view.ViewPager;
-import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;


### PR DESCRIPTION
Before this PR:
> Due to incorrect `draftId`, draft was not getting updated. Hence a terrible draft experience was presented to the user

Applying this PR:
> Fixes the draft saving in contest editor. It is now stable and saves all the drafts.